### PR TITLE
Update learn.juvix

### DIFF
--- a/docs/tutorials/learn.juvix
+++ b/docs/tutorials/learn.juvix
@@ -114,8 +114,6 @@ module NList-example;
   --8<-- [end:NList]
 
   --8<-- [start:nlength]
-  -- Nat here is the built-in type for natural numbers
-  -- coming from the standard library
   nlength : NList -> Nat;
   nlength nnil := 0;
   nlength (ncons _ xs) := nlength xs + 1;


### PR DESCRIPTION
Remove spurious comment. By that point in the tutorial it's been explained already that Nat is a natural number type from the standard library.
