### PR TITLE
Fix wrong -e header in fetch files

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -118,7 +118,7 @@ HEADER := "---\\nnobuttons: true\\n---\\n"
 .PHONY: juvix-metafiles
 juvix-metafiles: juvix-sources
 	@for file in $(METAFILES); do \
-		echo -e "$(HEADER)" | \
+		echo "$(HEADER)" | \
 			cat - ${COMPILERSOURCES}/$$file > temp  \
 			&& mv temp docs/$$file; \
 	done


### PR DESCRIPTION
Before, `echo` command for fetching some metafiles used `-e` options which lead to incorrect header in those files,:

```
-e ---
nobuttons: true
---
```

With this fix, now the correct header is added to those files:

```
---
nobuttons: true
---
```
