### PR TITLE
Fix the quickstart guide

### DIFF
--- a/docs/howto/quick-start.md
+++ b/docs/howto/quick-start.md
@@ -20,6 +20,7 @@ juvix init
 ```
 
 Evaluate a source file:
+
 ```shell
 juvix eval path/to/source.juvix
 ```

--- a/docs/howto/quick-start.md
+++ b/docs/howto/quick-start.md
@@ -19,7 +19,12 @@ Create a new package:
 juvix init
 ```
 
-Compile a source file into an executable:
+Evaluate a source file:
+```shell
+juvix eval path/to/source.juvix
+```
+
+Compile a source file into a native executable:
 
 ```shell
 juvix compile path/to/source.juvix
@@ -28,7 +33,7 @@ juvix compile path/to/source.juvix
 Compile a source file into a WebAssembly binary:
 
 ```shell
-juvix compile -t wasm path/to/source.juvix
+juvix compile -t wasm32-wasi path/to/source.juvix
 ```
 
 Launch the REPL:
@@ -82,6 +87,6 @@ How-to](./howto/installing.md) for more
 information. You can also run `juvix doctor` to check your setup.
 
 ```shell
-juvix compile --target wasm HelloWorld.juvix
+juvix compile --target wasm32-wasi HelloWorld.juvix
 wasmer HelloWorld.wasm
 ```

--- a/docs/index.md
+++ b/docs/index.md
@@ -26,7 +26,7 @@ section](./overview.md).
     Learn how to [install Juvix](./howto/installing.md) on macOS or Linux, as well as compile and
    document your Juvix projects.
 
-    [:octicons-arrow-right-24: Quick start ](./quick-start.md)
+    [:octicons-arrow-right-24: Quick start ](./howto/quick-start.md)
 
     [:octicons-arrow-right-24: How-to guides ](./howto/installing.md)
 

--- a/docs/tutorials/learn.md
+++ b/docs/tutorials/learn.md
@@ -95,10 +95,10 @@ Stdlib.Prelude> swap (1, 2)
 ## Files, modules and compilation
 
 Currently, the REPL does not support adding new definitions. To define
-new functions or data types, you need to put them in a separate file and
-either load the file in the REPL with `:load file.juvix` or compile the
-file to a binary executable with the shell command
-`juvix compile file.juvix`.
+new functions or data types, you need to put them in a separate file
+and either load the file in the REPL with `:load file.juvix`, evaluate
+it with the shell command `juvix eval file.juvix`, or compile it to a
+binary executable with `juvix compile file.juvix`.
 
 To conveniently edit Juvix files, an [Emacs mode](./emacs.md) and a
 [VSCode extension](./vscode.md) are available.


### PR DESCRIPTION
* Move it under `howto/`
* Fix WebAssembly target name
* Mention the `eval` command
