### PR TITLE
Add Talks page with the links to the videos

### DIFF
--- a/docs/about/talks.md
+++ b/docs/about/talks.md
@@ -8,5 +8,10 @@ applications.
 
 Gain valuable insights and inspiration from our presentations at various conferences.
 
-- ["Juvix"](https://youtu.be/T8jkl7_BMAY) _@Privacy Evolution 22_ by **Paul Cadman**
-- ["Juvix: Towards a Functional Programming Language for Decentralized Applications and Beyond"](https://youtu.be/YAOFCQTAhUI) _@ETHPrague2023_ by **Veronika Romashkina**
+## 2023
+
+- Veronika Romashkina (2023, July 10). **Juvix: Towards a Functional Programming Language for Decentralized Applications and Beyond** [Video]. Retrieved from YouTube. [Link to the video](https://youtu.be/YAOFCQTAhUI)
+
+## 2022
+
+- Paul Cadman (2022, July 20). **Juvix** [Video]. Retrieved from YouTube. [Link to the video](https://youtu.be/T8jkl7_BMAY)

--- a/docs/about/talks.md
+++ b/docs/about/talks.md
@@ -1,0 +1,12 @@
+# Talks and workshops
+
+On this page you will find a collection of our talks and workshop videos showcasing Juvix.
+
+In these videos we delve into the fascinating world of this powerful language,
+uncovering its core principles, and demonstrating real-world examples of Juvix
+applications.
+
+Gain valuable insights and inspiration from our presentations at various conferences.
+
+- ["Juvix"](https://youtu.be/T8jkl7_BMAY) _@Privacy Evolution 22_ by **Paul Cadman**
+- ["Juvix: Towards a Functional Programming Language for Decentralized Applications and Beyond"](https://youtu.be/YAOFCQTAhUI) _@ETHPrague2023_ by **Veronika Romashkina**

--- a/docs/index.md
+++ b/docs/index.md
@@ -47,14 +47,12 @@ section](./overview.md).
 
     [:octicons-arrow-right-24: Read the book](./explanations/README.md) -->
 
--  :fontawesome-solid-book-open:{ .lg .middle } __Talks and Workshops__
+-  :fontawesome-solid-video:{ .lg .middle } __Talks and Workshops__
 
     ---
 
     A collection of talks and workshop videos showcasing Juvix. Gain valuable
     insights and inspiration from our presentations at various conferences.
-
-    core principles, and demonstrating real-world examples of Juvix applications
 
     [:octicons-arrow-right-24: Juvix videos](./about/talks.md)
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -39,13 +39,24 @@ section](./overview.md).
 
     [:octicons-arrow-right-24: Learn Juvix in 5 minutes](./tutorials/learn)
 
--  :fontawesome-solid-book-open:{ .lg .middle } __Explanations__
+<!-- -  :fontawesome-solid-book-open:{ .lg .middle } __Explanations__
 
     ---
 
     A series dedicated to delivering more in-depth technical explanations of Juvix.
 
-    [:octicons-arrow-right-24: Read the book](./explanations/README.md)
+    [:octicons-arrow-right-24: Read the book](./explanations/README.md) -->
+
+-  :fontawesome-solid-book-open:{ .lg .middle } __Talks and Workshops__
+
+    ---
+
+    A collection of talks and workshop videos showcasing Juvix. Gain valuable
+    insights and inspiration from our presentations at various conferences.
+
+    core principles, and demonstrating real-world examples of Juvix applications
+
+    [:octicons-arrow-right-24: Juvix videos](./about/talks.md)
 
 -   :fontawesome-solid-lines-leaning:{ .lg .middle } __Reference__
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,0 +1,6 @@
+{
+  "name": "juvix-docs",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {}
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,0 @@
-{
-  "name": "juvix-docs",
-  "lockfileVersion": 3,
-  "requires": true,
-  "packages": {}
-}


### PR DESCRIPTION
Adding it as a separate page, also highlighting in the separate section on the main index page.
I remove the Explanation section for now from the highlights as it is still not that loaded with info.
I will bring it back when it will look more full. Anyway, there is other ways to access the explanations 🙂 