### PR TITLE
Add blog link on the front page

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -72,6 +72,7 @@ section](./overview.md).
     Check out our blog to discover new features in the upcoming release, along
     with helpful examples and more. And, don't forget to join us on [Discord].
 
+    [:octicons-arrow-right-24: Blog](./blog)
     [:octicons-arrow-right-24: Join us](./about/community.md)
 
 -   :material-scale-balance:{ .lg .middle } __Open Source, GPL3.0__


### PR DESCRIPTION
The "blog" section on the front page didn't actually have a link to the blog
