### PR TITLE
Makefile: format all packages in the repo

### DIFF
--- a/docs/howto/compilation/HelloWorld.juvix
+++ b/docs/howto/compilation/HelloWorld.juvix
@@ -3,10 +3,10 @@ module HelloWorld;
 --8<-- [start:Hello]
 -- This is a comment.
 module Hello;
+  
+  -- Importing the 'String' type from standard library prelude
+  import Stdlib.Prelude open;
 
--- Importing the 'String' type from standard library prelude
-import Stdlib.Prelude open;
-
-main : String := "Hello world!";
+  main : String := "Hello world!";
 --8<-- [end:Hello]
 end;

--- a/docs/index/IntentExample.juvix
+++ b/docs/index/IntentExample.juvix
@@ -19,7 +19,8 @@ module AliceIntent;
         createdHashes : List LogicHash :=
           map Resource.logicHash createdRs;
       in isCreated kind
-        || (quantityOfDenom Dolphin.denomination createdRs == ofNat 1
+        || (quantityOfDenom Dolphin.denomination createdRs
+            == ofNat 1
           && quantityOfDenom A.denomination createdRs == ofNat 1)
         || quantityOfDenom Dolphin.denomination createdRs == ofNat 1
         && quantityOfDenom B.denomination createdRs == ofNat 2;

--- a/docs/reference/language/aliases.juvix
+++ b/docs/reference/language/aliases.juvix
@@ -23,9 +23,9 @@ not2 (b : Boolean) : Boolean :=
     syntax alias yes := ⊤;
     syntax alias no := ⊥;
   in case b of {
-    | no := yes
-    | yes := no
-  };
+       | no := yes
+       | yes := no
+     };
 --8<-- [end:inside-body]
 
 --8<-- [start:export]
@@ -44,20 +44,21 @@ syntax operator || logical;
 --8<-- [end:export]
 
 module fixityInherit;
---8<-- [start:or-inherit]
-    syntax alias or := ||;
-    newor (a b c : Binary) : Binary := (a or b) or c;
+  --8<-- [start:or-inherit]
+  syntax alias or := ||;
+
+  newor (a b c : Binary) : Binary := (a or b) or c;
 --8<-- [end:or-inherit]
 end;
 
 module fixityNone;
---8<-- [start:or-fixity-none]
-syntax operator or none; 
-syntax alias or := ||;
-or3 (a b c : Binary) : Binary := or (or a b) c;
+  --8<-- [start:or-fixity-none]
+  syntax operator or none;
+  syntax alias or := ||;
+
+  or3 (a b c : Binary) : Binary := or (or a b) c;
 --8<-- [end:or-fixity-none]
 end;
-
 
 type Pair := mkPair Binary Binary;
 

--- a/docs/reference/language/functions.juvix
+++ b/docs/reference/language/functions.juvix
@@ -84,6 +84,7 @@ end;
 module default-values;
   --8<-- [start:defaultValues]
   import Stdlib.Prelude open;
-  f {x : Nat := 0}  {y : Nat := 1} :  Nat := x + y;
-  --8<-- [end:defaultValues]
+
+  f {x : Nat := 0} {y : Nat := 1} : Nat := x + y;
+--8<-- [end:defaultValues]
 end;

--- a/docs/reference/language/records.juvix
+++ b/docs/reference/language/records.juvix
@@ -40,9 +40,9 @@ p1' : Pair T T :=
 --8<-- [start:syntax-variant-record-term]
 p1'' : Pair T T :=
   mkPair@{
-    fst := Pair.fst p1; 
+    fst := Pair.fst p1;
     snd := Pair.snd p1
-    };
+  };
 --8<-- [end:syntax-variant-record-term]
 
 --8<-- [start:openrecord]


### PR DESCRIPTION
Previously no sub-packages were checked because `juvix format` does not traverse into Juvix sub-packages.  

* `make format-juvix-files` now formats all packages in the repo
* `make check-format-juvix-files` fails if a package is not formatted

