### PR TITLE
Rename taiga-simulator to abstract-resource-machine-simulator

### DIFF
--- a/docs/Package.juvix
+++ b/docs/Package.juvix
@@ -24,7 +24,7 @@ github "anoma" "juvix-quickcheck" "v0.9.0"
 github "anoma" "juvix-stdlib" "v0.1.0"
 --8<-- [end:juvix-stdlib]
 ;
---8<- [start:taiga-simulator]
-github "anoma" "taiga-simulator" "b4ca947a2772a2b5c1b862621754767188a008e3"
---8<-- [end:taiga-simulator]
+--8<- [start:abstract-resource-machine-simulator]
+github "anoma" "abstract-resource-machine-simulator" "b4ca947a2772a2b5c1b862621754767188a008e3"
+--8<-- [end:abstract-resource-machine-simulator]
 ]};

--- a/docs/index.juvix.md
+++ b/docs/index.juvix.md
@@ -85,7 +85,7 @@ hand, is willing to exchange one unit of resource `A` for 1 `Dolphin`. How can w
 write these intents in Juvix? The conditions for Alice's intent is presented in
 Juvix on the right, a **logic function** that validates the transaction.
 
-See [here](https://anoma.github.io/taiga-simulator/Apps.TwoPartyExchange-src.html#1184) the full Juvix code for this example.
+See [here](https://anoma.github.io/abstract-resource-machine-simulator/Apps.TwoPartyExchange-src.html#1184) the full Juvix code for this example.
 
 <div class="grid cards" style="text-align:center" markdown>
 
@@ -107,7 +107,7 @@ See [here](https://anoma.github.io/taiga-simulator/Apps.TwoPartyExchange-src.htm
 
 <div markdown>
 
-## :octicons-mark-github-16: [`anoma/taiga-simulator`](https://github.com/anoma/taiga-simulator)
+## :octicons-mark-github-16: [`anoma/abstract-resource-machine-simulator`](https://github.com/anoma/abstract-resource-machine-simulator)
 
 === "Alice Intent"
 
@@ -198,7 +198,7 @@ See [here](https://anoma.github.io/taiga-simulator/Apps.TwoPartyExchange-src.htm
 
 <!-- !!!info "Note"
 
-    See also the Sudoku intent example: [here](https://anoma.github.io/taiga-simulator/Apps.Sudoku.html#). -->
+    See also the Sudoku intent example: [here](https://anoma.github.io/abstract-resource-machine-simulator/Apps.Sudoku.html#). -->
 
 </div>
 </div>
@@ -208,7 +208,7 @@ See [here](https://anoma.github.io/taiga-simulator/Apps.TwoPartyExchange-src.htm
 
     How to write intents in Juvix to validate transactions in Anoma is further
     elaborated in both the [Taiga
-    Simulator](https://github.com/anoma/taiga-simulator) repository and the [Juvix
+    Simulator](https://github.com/anoma/abstract-resource-machine-simulator) repository and the [Juvix
     Workshop](https://github.com/anoma/juvix-workshop).
 
 === "Transaction lifecycle"

--- a/docs/index/Package.juvix
+++ b/docs/index/Package.juvix
@@ -7,5 +7,5 @@ package : Package :=
     {name := "docs";
      version := mkVersion 0 0 1;
      dependencies := [ git "stdlib" "https://github.com/anoma/juvix-stdlib" "f68b0614ad695eaa13ead42f3466e0a78219f826"
-                     ; git "taiga-simulator" "https://github.com/anoma/taiga-simulator" "bcb9971b32aed93bdb1121182f41057d9625e0a9"
+                     ; git "abstract-resource-machine-simulator" "https://github.com/anoma/abstract-resource-machine-simulator" "bcb9971b32aed93bdb1121182f41057d9625e0a9"
                      ]};

--- a/docs/index/juvix.lock.yaml
+++ b/docs/index/juvix.lock.yaml
@@ -10,9 +10,9 @@ dependencies:
     url: https://github.com/anoma/juvix-stdlib
   dependencies: []
 - git:
-    name: taiga-simulator
+    name: abstract-resource-machine-simulator
     ref: bcb9971b32aed93bdb1121182f41057d9625e0a9
-    url: https://github.com/anoma/taiga-simulator
+    url: https://github.com/anoma/abstract-resource-machine-simulator
   dependencies:
   - git:
       name: stdlib

--- a/docs/juvix-packages.md
+++ b/docs/juvix-packages.md
@@ -101,7 +101,7 @@ the directory of your project.
 
 <div class="grid cards" markdown>
 
-- :octicons-mark-github-16: [`anoma/taiga-simulator`](https://github.com/anoma/taiga-simulator)
+- :octicons-mark-github-16: [`anoma/abstract-resource-machine-simulator`](https://github.com/anoma/abstract-resource-machine-simulator)
 
     ***
 
@@ -114,7 +114,7 @@ the directory of your project.
         Add the following to your `Package.juvix` file in the `dependencies` field:
 
         ```text
-        --8<------ "docs/Package.juvix:taiga-simulator"
+        --8<------ "docs/Package.juvix:abstract-resource-machine-simulator"
         ```
     
 

--- a/docs/juvix.lock.yaml
+++ b/docs/juvix.lock.yaml
@@ -40,9 +40,9 @@ dependencies:
     url: https://github.com/anoma/juvix-stdlib
   dependencies: []
 - git:
-    name: anoma_taiga-simulator
+    name: anoma_abstract-resource-machine-simulator
     ref: b4ca947a2772a2b5c1b862621754767188a008e3
-    url: https://github.com/anoma/taiga-simulator
+    url: https://github.com/anoma/abstract-resource-machine-simulator
   dependencies:
   - git:
       name: anoma_juvix-stdlib


### PR DESCRIPTION
The taiga-simulator is now called https://github.com/anoma/abstract-resource-machine-simulator/