### PR TITLE
Remove git-committers

### DIFF
--- a/mkdocs.insiders.yml
+++ b/mkdocs.insiders.yml
@@ -60,10 +60,6 @@ plugins:
       enabled: true
       strict: true
 
-  - git-committers:
-      repository: anoma/juvix-docs
-      branch: main
-
   - rss:
       match_path: blog/posts/.*
       date_from_meta:

--- a/requirements.txt
+++ b/requirements.txt
@@ -5,7 +5,6 @@ mkdocs-blog-plugin
 mkdocs-git-revision-date-plugin
 mkdocs-pdf-export-plugin
 mkdocs-git-revision-date-localized-plugin
-mkdocs-git-committers-plugin-2
 mkdocs-git-authors-plugin
 mkdocs-rss-plugin
 mike


### PR DESCRIPTION
We're hitting API rate limiting on deployment due to this plugin:

```
ERROR   -  git-committers:   403 rate limit exceeded - You may have exceeded the API rate limit or need to be authorized. You can set a token under 'token' mkdocs.yml config or MKDOCS_GIT_COMMITTERS_APIKEY environment variable.
```

https://github.com/anoma/juvix-docs/actions/runs/8520966647/job/23338176672

We can live without this feature in the docs for now.
