### PR TITLE
Disable material MkDocs privacy plugin

### DIFF
--- a/mkdocs.insiders.yml
+++ b/mkdocs.insiders.yml
@@ -3,16 +3,6 @@ plugins:
   - juvix
   - offline:
       enabled: !ENV [OFFLINE, false]
-  - privacy:
-      enabled: !ENV [CI, false]
-      links_attr_map:
-        target: _blank
-      assets_exclude:
-        - cdn.jsdelivr.net/npm/mathjax@3/*
-        - giscus.app/*
-        - github.com/*
-        - unpkg.com/*
-        - docs.juvix.org/*
 
   - search:
       # lang: en


### PR DESCRIPTION
See failure: https://github.com/anoma/juvix-docs/actions/runs/8552115199/job/23432563214

```
OSError: [Errno 36] File name too long:
'/home/runner/work/juvix-docs/juvix-docs/.cache/plugin/privacy/assets/external/fonts.gstatic.com/s/robotoflex/v26/NaNnepOXO_NexZs0b5QrzlOHb8wCikXpYqmZsWI-__OGbt8jZktqc2V3Zs0KvDLdBP8SBZtOs2IifRuUZQMsPJtUsR4DEK6cULNeUx9XgTnH37Ha_FIAp4Fm0PP1hw45DntW2x0wZGzhPmr1YNMYKYn9_1IQXGwJAiUJVUMdN5YUW4O8HtSoXjC1z3QSabshNFVe3e0O5j3ZjrZCu23Qd4G0EBysQNK-QKavMl1cKq3tHXtXi8mzLjaAcbuknRNC.woff2'
```

We can live without the [privacy plugin](https://squidfunk.github.io/mkdocs-material/plugins/privacy/) for now.

