### PR TITLE
Update tutorial title and intro

### DIFF
--- a/docs/README.juvix.md
+++ b/docs/README.juvix.md
@@ -73,9 +73,9 @@ Discord][anomaDiscord]. -->
     Learn how to [install Juvix](./howto/installing.md) on macOS or Linux, as well as compile and
    document your Juvix projects.
 
-    [:octicons-arrow-right-24: Quick start ](./howto/quick-start.md)
+    [:octicons-arrow-right-24: Quick start](./howto/quick-start.md)
 
-    [:octicons-arrow-right-24: How-to guides ](./howto/installing.md)
+    [:octicons-arrow-right-24: How-to guides](./howto/installing.md)
 
 -   :material-clock-fast:{ .lg .middle } __Tutorials__
 
@@ -84,15 +84,7 @@ Discord][anomaDiscord]. -->
     Master the essentials of Juvix through a series of
     tailored examples, tutorials and technical explanations.
 
-    [:octicons-arrow-right-24: Learn Juvix in 5 minutes](./tutorials/learn.html)
-
-<!-- -  :fontawesome-solid-book-open:{ .lg .middle } __Explanations__
-
-    ---
-
-    A series dedicated to delivering more in-depth technical explanations of Juvix.
-
-    [:octicons-arrow-right-24: Read the book](./explanations/README.md) -->
+    [:octicons-arrow-right-24: Functional programming with Juvix](./tutorials/learn.html)
 
 -  :fontawesome-solid-video:{ .lg .middle } __Talks and Workshops__
 

--- a/docs/tutorials/learn.juvix.md
+++ b/docs/tutorials/learn.juvix.md
@@ -5,7 +5,7 @@ search:
   boost: 2
 tags:
   - tutorial
-  - beginner
+  - intermediate
   - functional-programming
 ---
 
@@ -13,15 +13,15 @@ tags:
 module tutorials.learn;
 ```
 
-# Juvix tutorial
+# Functional programming with Juvix
 
 ![tara-teaching](./../assets/images/tara-teaching.svg){ align=left width="280" }
 
-Welcome to the Juvix tutorial! This concise guide will introduce you to
-essential language features, while also serving as an introduction to functional
-programming. By the end of this tutorial, you'll have a strong foundation in
-Juvix's core concepts, ready to explore its advanced capabilities. Let's get
-started on your Juvix journey!
+Welcome to the Juvix functional programming tutorial! This thorough
+guide provides a structured introduction to Juvix language features
+and functional programming concepts. By the end of this tutorial,
+you'll have a strong foundation in functional programming with
+Juvix. Let's get started on your Juvix journey!
 
 ## Juvix REPL
 
@@ -994,11 +994,9 @@ case tail' lst of
 
 ## Exercises
 
-You have now learnt the very basics of Juvix. To consolidate your understanding
-of Juvix and functional programming, try doing some of the following exercises.
-To learn how to write more complex Juvix programs, see the [advanced
-tutorial](./../examples/html/Tutorial/Tutorial.html) and the [Juvix program
-examples](../reference/examples.md).
+You have now learnt essential functional programming techniques in
+Juvix. To consolidate your understanding, try doing some of the
+following exercises.
 
 <!-- Include solutions as details -->
 
@@ -1010,7 +1008,7 @@ Let's start by defining some functions on booleans.
 
 The type for booleans is defined in the standard library like this:
 
-```juvix extract-module-statements 1
+```juvix extract-module-statements
 module Bool-Ex;
 
   type Bool :=
@@ -1019,7 +1017,7 @@ module Bool-Ex;
 end;
 ```
 
-Remember that you can \import this definition by adding `import Stdlib.Prelude
+Remember that you can import this definition by adding `import Stdlib.Prelude
 open` at the beginning of your module.
 
 Now, define the logical function `not` by using pattern matching.
@@ -1384,7 +1382,7 @@ Can you make the `compose` function polymorphic and as general as possible?
     end;
     ```
 
-Congratulations! your warm-up is complete!
+Congratulations! Your warm-up is complete!
 
 ### More exercises
 

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -140,7 +140,7 @@ nav:
       - Judoc documentation tool: ./howto/judoc.md
 
   - Tutorials:
-      - Learn Juvix in minutes: ./tutorials/learn.juvix.md
+      - Functional programming with Juvix: ./tutorials/learn.juvix.md
       - Juvix VSCode extension: ./tutorials/vscode.juvix.md
       - Juvix Emacs mode: ./tutorials/emacs.juvix.md
 


### PR DESCRIPTION
* Change tutorial title to "Functional programming with Juvix"
* Reformulate the introductory paragraph to explain that this is not a quick basic tutorial, but a guide to functional programming concepts in Juvix.
