### PR TITLE
Make all pages accessible without going through the navigation menu

### DIFF
--- a/docs/README.juvix.md
+++ b/docs/README.juvix.md
@@ -75,7 +75,7 @@ Discord][anomaDiscord]. -->
 
     [:octicons-arrow-right-24: Quick start](./howto/quick-start.md)
 
-    [:octicons-arrow-right-24: How-to guides](./howto/installing.md)
+    [:octicons-arrow-right-24: How-to guides](./howto/README.md)
 
 -   :material-clock-fast:{ .lg .middle } __Tutorials__
 
@@ -85,6 +85,8 @@ Discord][anomaDiscord]. -->
     tailored examples, tutorials and technical explanations.
 
     [:octicons-arrow-right-24: Functional programming with Juvix](./tutorials/learn.html)
+
+    [:octicons-arrow-right-24: Tutorials](./tutorials/README.md)
 
 -  :fontawesome-solid-video:{ .lg .middle } __Talks and Workshops__
 
@@ -99,10 +101,14 @@ Discord][anomaDiscord]. -->
 
     ---
 
-    Explore the Language reference, milestone examples, and tooling
+    Explore the language reference, milestone examples, and tooling
     documentation!
 
-    [:octicons-arrow-right-24: Reference](./reference/language/README.md)
+    [:octicons-arrow-right-24: Reference](./reference/README.md)
+
+    [:octicons-arrow-right-24: Standard library](https://anoma.github.io/juvix-stdlib/index.html)
+
+    [:octicons-arrow-right-24: Packages and projects](./juvix-packages.md)
 
 -   :material-account-group:{ .lg .middle } __Blog__
 

--- a/docs/howto/README.md
+++ b/docs/howto/README.md
@@ -1,0 +1,14 @@
+---
+icon: material/label-outline
+comments: false
+search:
+  boost: 4
+hide:
+  - toc
+---
+
+- [Installing Juvix](./installing.md)
+- [Compiling programs](./compilation.md)
+- [Setting up a project](./project.md)
+- [Contributing](./contributing.md)
+- [Judoc documentation tool](./judoc.md)

--- a/docs/reference/README.md
+++ b/docs/reference/README.md
@@ -1,0 +1,46 @@
+---
+icon: material/label-outline
+comments: false
+search:
+  boost: 4
+hide:
+  - toc
+---
+
+## Language reference
+
+- [Functions](./language/functions.html)
+- [Builtins](./language/builtins.html)
+- [Data types](./language/datatypes.html)
+- [Records](./language/records.html)
+- [Traits](./language/traits.html)
+- [Modules](./language/modules.md)
+- [Local definitions](./language/lets.html)
+- [Control structures](./language/control.html)
+- [Comments](./language/comments.md)
+- [Pragmas](./language/pragmas.html)
+- [Axioms](./language/axioms.html)
+
+### Syntax extensions
+
+- [Aliases](./language/aliases.html)
+- [Iterators](./language/iterators.md)
+- [Fixities](./language/fixity.html)
+- [Operators](./language/operators.html)
+
+### Libraries and projects
+
+- [Standard library](./stdlib.md)
+- [Example programs](./examples.md)
+
+## Tooling
+
+- [Documentation tool](./judoc.md)
+- [Command line interface](./tooling/CLI.md)
+- [Doctor](./tooling/doctor.md)
+- [Emacs mode](./tooling/emacs.md)
+- [Haskell test suite](./tooling/testing.md)
+
+## Compiler implementation
+
+- [Compiler pipeline](./compiler.md)

--- a/docs/reference/language/README.md
+++ b/docs/reference/language/README.md
@@ -7,14 +7,40 @@ hide:
   - toc
 ---
 
-Juvix is designed with a focus on safety. The Juvix compiler runs several
-static analyses which guarantee the absence of runtime errors. Analyses
-performed include termination and type checking.
+## Language reference
 
-The Juvix module system allows developers to break down their programs into
-smaller, reusable modules that can be compiled separately and combined to create
-larger programs. These modules can be used to build libraries, which can then be
-documented using Juvix's built-in documentation generation tool, see for
-example, [the Juvix standard library's website][stdlib].
+- [Functions](../language/functions.html)
+- [Builtins](../language/builtins.html)
+- [Data types](../reference/language/datatypes.juvix.md)
+- [Records](./reference/language/records.juvix.md)
+- [Traits](./reference/language/traits.juvix.md)
+- [Modules](./reference/language/modules.md)
+- [Local definitions](./reference/language/lets.juvix.md)
+- [Control structures](./reference/language/control.juvix.md)
+- [Comments](./reference/language/comments.md)
+- [Pragmas](./reference/language/pragmas.juvix.md)
+- [Axioms](./reference/language/axioms.juvix.md)
 
-[stdlib]: https://anoma.github.io/juvix-stdlib/
+### Syntax extensions
+
+- [Aliases](./reference/language/aliases.juvix.md)
+- [Iterators](./reference/language/iterators.md)
+- [Fixities](./reference/language/fixity.juvix.md)
+- [Operators](./reference/language/operators.juvix.md)
+
+### Libraries and projects
+
+- [Standard library](./reference/stdlib.md)
+- [Example programs](./reference/examples.md)
+
+## Tooling
+
+- [Documentation tool](./reference/judoc.md)
+- [Command line interface](./reference/tooling/CLI.md)
+- [Doctor](./reference/tooling/doctor.md)
+- [Emacs mode](./reference/tooling/emacs.md)
+- [Haskell test suite](./reference/tooling/testing.md)
+
+## Compiler implementation
+
+- [Compiler pipeline](./reference/compiler.md)

--- a/docs/tutorials/README.md
+++ b/docs/tutorials/README.md
@@ -1,0 +1,12 @@
+---
+icon: material/label-outline
+comments: false
+search:
+  boost: 4
+hide:
+  - toc
+---
+
+- [Functional programming with Juvix](./learn.html)
+- [Juvix VSCode extension](./vscode.html)
+- [Juvix Emacs mode](./emacs.html)

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -133,6 +133,7 @@ nav:
   - ./README.juvix.md
 
   - How-to guides:
+      - How-to guides: ./howto/README.md
       - Installing Juvix: ./howto/installing.md
       - Compiling programs: ./howto/compilation.md
       - Setting up a project: ./howto/project.md
@@ -140,13 +141,14 @@ nav:
       - Judoc documentation tool: ./howto/judoc.md
 
   - Tutorials:
+      - Tutorials: ./tutorials/README.md
       - Functional programming with Juvix: ./tutorials/learn.juvix.md
       - Juvix VSCode extension: ./tutorials/vscode.juvix.md
       - Juvix Emacs mode: ./tutorials/emacs.juvix.md
 
   - Reference:
       - Language reference:
-          - About: ./reference/language/README.md
+          - Reference: ./reference/README.md
           - Functions: ./reference/language/functions.juvix.md
           - Builtins: ./reference/language/builtins.juvix.md
           - Data types: ./reference/language/datatypes.juvix.md


### PR DESCRIPTION
On many browsers, if the window is too small the navigation menus at the top and on the left just don't display. Instead, there is just a single button in the top-left corner which is easy to miss.

Hence, all pages should be accessible without going through the generated navigation menu. This PR adds more links on the front page and creates top-level pages with links for "How-to guides", "Reference" and "Tutorials".
