### PR TITLE
docs: Fix typos and improve readability across documentation

### DIFF
--- a/docs/howto/contributing.md
+++ b/docs/howto/contributing.md
@@ -12,7 +12,7 @@ big or small, of any kind. We appreciate any help/feedback we can get.
 
 Make sure you have followed the [installation instructions][installation] and
 have a working Juvix installation. You can also use the web-based development
-environment ready to the Juvix development, [Juvix Github
+environment ready for Juvix development, [Juvix Github
 Codespace][juvix-codespace]
 
 1. Fork the repository.

--- a/docs/howto/quick-start.md
+++ b/docs/howto/quick-start.md
@@ -92,4 +92,4 @@ You can also evaluate the file without compiling it first by executing
 juvix eval HelloWorld.juvix
 ```
 
-The output should be the same : `hello world!`.
+The output should be the same: `hello world!`.

--- a/docs/juvix-packages.md
+++ b/docs/juvix-packages.md
@@ -8,7 +8,7 @@ hide:
 
 ## Quick Start
 
-To install a package, you must sure that you have created the `Package.juvix`
+To install a package, you must make sure that you have created the `Package.juvix`
 file. You can run `juvix init` to get a template `Package.juvix` file. A more
 detailed description on the usage of `Package.juvix` can be found in [*How to
 setup a Juvix project*](./howto/project.md). For now, one example is
@@ -99,7 +99,7 @@ the directory of your project.
 
 </div>
 
-Please let us know if you are using Juvix in your project. Opening an issue or a
+Please let us know if you are using Juvix in your project. Open an issue or a
 pull request to add it to this list.
 
 Check out other examples of Juvix programs in the [examples/milestone](./reference/examples.md).

--- a/docs/reference/judoc.md
+++ b/docs/reference/judoc.md
@@ -91,7 +91,7 @@ For instance, the following is a paragraph with two _lines_:
 --- Second line
 ```
 
-Note that a rendered paragraph will have have no line breaks. If you want to
+Note that a rendered paragraph will have no line breaks. If you want to
 have line breaks, you will need to split the paragraph. Hence, the paragraph
 above will be rendered as
 

--- a/docs/reference/language/modules.md
+++ b/docs/reference/language/modules.md
@@ -46,7 +46,7 @@ convention. That is, if `dir` is the root of a project, then the module in
 
 ## _Import_ and _open_ statements
 
-In order to access the definitions from another modules we use an
+In order to access the definitions from other modules we use an
 _import_ statement. To import some module named `Data.List` we will write
 
 ```juvix

--- a/docs/reference/language/syntax.md
+++ b/docs/reference/language/syntax.md
@@ -65,7 +65,7 @@ It may have multiple patterns:
 --8<-- [end:function-pattern-matching-multiple-arguments]
 ```
 
-Lambdas
+### Lambdas
 
 ```
 --8<-- [start:function-lambda]

--- a/docs/reference/tooling/doctor.md
+++ b/docs/reference/tooling/doctor.md
@@ -8,7 +8,7 @@ comments: true
 # Juvix Doctor
 
 The `juvix doctor` command can help you to troubleshoot problems with
-your development environment. For each problem the doctor finds they'll
+your development environment. For each problem the doctor finds, there will
 be a link to a section on this page to help you fix it.
 
 ## Could not find the clang command

--- a/docs/tutorials/learn.juvix.md
+++ b/docs/tutorials/learn.juvix.md
@@ -23,7 +23,7 @@ and functional programming concepts. By the end of this tutorial,
 you'll have a strong foundation in functional programming with
 Juvix.
 
-Before reading this tutorial, it is recommended to work through the [Essential Juvix](./essential.html) tutorial which introduces basic Juvix freatures. Here we focus on explaining the Juvix language more thoroughly and on employing common functional programming techniques.
+Before reading this tutorial, it is recommended to work through the [Essential Juvix](./essential.html) tutorial which introduces basic Juvix features. Here we focus on explaining the Juvix language more thoroughly and on employing common functional programming techniques.
 
 ## Data types and functions
 


### PR DESCRIPTION
## Description

Please provide a **clear** and **concise** description of the documentation changes you're proposing in this PR.

- docs/howto/quick-start.md: Remove extra space before colon
- docs/howto/contributing.md: Fix preposition 'ready to' → 'ready for'
- docs/reference/language/syntax.md: Add proper heading format for 'Lambdas'
- docs/reference/tooling/doctor.md: Fix grammar 'they'll be' → 'there will be'
- docs/juvix-packages.md: Add missing word 'make sure' and fix sentence structure
- docs/reference/judoc.md: Remove duplicate word 'have have' → 'have'
- docs/reference/language/modules.md: Fix grammar 'another modules' → 'other modules'
- docs/tutorials/learn.juvix.md: Fix typo 'freatures' → 'features'


Related Issue: # (issue number, if applicable)

N/A 

## Checklist

- [X] My writing follows the style guidelines of this project.
- [X] I have checked for and corrected any spelling or grammar errors.
- [X] I have performed a self-review of my own writing.
- [X] I have made corresponding changes to existing documentation.
- [X] My changes generate no new warnings or errors using `make pre-commit`.
- [X ] If I have added or modified a code example, I have tested that the example
      compiles and runs as expected with the latest version of Juvix.

## Additional Information

Please provide any additional context or information about the proposed documentation changes here.
